### PR TITLE
Bulma modal prompts

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -13,11 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (!service_name) {
 
-        const modal_id = 'service_name_container'
-
-        const modal_prompt = 'Enter the name of the service you wish to track incidents for:'
-
-        Modal.inputUserIncident(storage, modal_id, modal_prompt) // Creates a user prompt to save incident name to local storage
+        Modal.modalPrompt(storage, 'Enter the name of the service you wish to track incidents for:') // Creates a user prompt to save incident name to local storage
 
         // service_name = prompt("Enter the name of the service you wish to track incidents for:")
 
@@ -171,25 +167,35 @@ document.addEventListener('DOMContentLoaded', () => {
 
     }
 
-    document.getElementById("reset_everything").addEventListener("click", () => {
+    // Reset protocol that creates bulma modals that confirm user wishes to clear local data
+    document.getElementById('reset_everything').addEventListener("click", () => {
 
-        Modal.resetProtocol(storage) // Three step protocol to reset local storage by prompting the user for confirmation
+        Modal.confirmReset('reset_warning_one', 'Do you wish to reset local storage?').then((confirmed) => {
 
-        // if (confirm("Are you sure you want to reset everything?")) {
+            if (confirmed) {
 
-        //     if (confirm("Are you absolutely sure you want to reset everything? This can NOT be undone.")) {
+                Modal.confirmReset('reset_warning_two', 'Resetting will delete all data: Are you sure?').then((confirmed) => {
 
-        //         if (prompt(`Type "Anthony is the best" to confirm that you definitely, absolutely, certainly wish to reset everything.`) == "Anthony is the best") {
-                    
-        //             storage.remove("service_name")
-        //             storage.remove("incidents")
-        //             location.reload()
+                    if (confirmed) {
 
-        //         }
+                        Modal.confirmReset('reset_warning_three', "Please type 'YES' to proceed.", 'YES').then((confirmed) => {
 
-        //     }
+                            confirmed ? (
 
-        // }
+                                storage.remove("service_name"),
+                                storage.remove("incidents"),
+                                location.reload()
+
+                            ) : undefined
+                        })
+
+                    }
+
+                })
+
+            }
+
+        })
 
     })
 

--- a/Main.js
+++ b/Main.js
@@ -167,7 +167,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     document.getElementById("set_service_name").addEventListener("click", () => {
 
-        Modal.modalPrompt(storage, 'Enter the name of the service you wish to track incidents for:') // Creates a user prompt to save incident name to local storage
+        Modal.modalPrompt(storage, 'Please enter the name of the service you wish to track incidents for.') // Creates a user prompt to save incident name to local storage
 
     })
 
@@ -182,7 +182,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
                     if (confirmed) {
 
-                        Modal.confirmReset('reset_warning_three', "Please type 'YES' to proceed.", 'YES').then((confirmed) => {
+                        Modal.confirmReset('reset_warning_three', "Please type 'YES' to proceed.", 'YES', 'req-input').then((confirmed) => {
 
                             confirmed ? (
 

--- a/Main.js
+++ b/Main.js
@@ -1,4 +1,4 @@
-import * as Modal from './Modal.js'
+import { Modal } from './Modal.js'
 import { LocalStorageInterface } from "./LocalStorageInterface.js";
 import { Incident } from "./Incident.js"
 
@@ -167,7 +167,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     document.getElementById("set_service_name").addEventListener("click", () => {
 
-        const promptUserIncidentName = new Modal.Modal('Enter the name of the service you wish to track incidents for.', 'Set Service Name')
+        const promptUserIncidentName = new Modal('Enter the name of the service you wish to track incidents for.', 'Set Service Name')
 
         promptUserIncidentName.prompt((input) => {
 
@@ -183,29 +183,29 @@ document.addEventListener('DOMContentLoaded', () => {
     // Reset protocol that creates bulma modals that confirm user wishes to clear local data
     document.getElementById('reset_everything').addEventListener("click", () => {
 
-        const confirmReset_1 = new Modal.Modal('Do you wish to reset local storage?')
-        const confirmReset_2 = new Modal.Modal('Resetting will delete all data. Are you sure?')
-        const confirmReset_3 = new Modal.Modal("Please type 'YES' to proceed.", 'Danger')
+        const confirmReset1 = new Modal('Do you wish to reset local storage?')
+        const confirmReset2 = new Modal('Resetting will delete all data. Are you sure?')
+        const confirmReset3 = new Modal("Please type 'YES' to proceed.", 'Danger')
 
-        confirmReset_1.confirm((e) => { 
+        confirmReset1.confirm((e) => { 
 
-            e && confirmReset_2.confirm((e) => {
+            e && confirmReset2.confirm((e) => {
 
-                e && confirmReset_3.prompt((e) => {
+                e && confirmReset3.prompt((e) => {
 
-                        e === 'YES' && (
-    
-                            storage.remove("service_name"),
-                            storage.remove("incidents"),
-                            location.reload()
-    
-                        )
+                    e === 'YES' && (
+
+                        storage.remove("service_name"),
+                        storage.remove("incidents"),
+                        location.reload()
+
+                    )
     
                 })
 
             })
 
-         })
+        })
 
     })
 

--- a/Main.js
+++ b/Main.js
@@ -167,7 +167,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     document.getElementById("set_service_name").addEventListener("click", () => {
 
-        const promptUserIncidentName = new Modal.Modal('Enter the name of the service you wish to track incidents for.', 'Set Service Name', true)
+        const promptUserIncidentName = new Modal.Modal('Enter the name of the service you wish to track incidents for.', 'Set Service Name')
 
         promptUserIncidentName.prompt((input) => {
 
@@ -185,7 +185,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const confirmReset_1 = new Modal.Modal('Do you wish to reset local storage?')
         const confirmReset_2 = new Modal.Modal('Resetting will delete all data. Are you sure?')
-        const confirmReset_3 = new Modal.Modal("Please type 'YES' to proceed.", 'Danger', true)
+        const confirmReset_3 = new Modal.Modal("Please type 'YES' to proceed.", 'Danger')
 
         confirmReset_1.confirm((e) => { 
 

--- a/Main.js
+++ b/Main.js
@@ -1,5 +1,7 @@
+import * as Modal from './Modal.js'
 import { LocalStorageInterface } from "./LocalStorageInterface.js";
 import { Incident } from "./Incident.js"
+
 
 document.addEventListener('DOMContentLoaded', () => {
 
@@ -11,15 +13,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (!service_name) {
 
-        service_name = prompt("Enter the name of the service you wish to track incidents for:")
+        const modal_id = 'service_name_container'
 
-        storage.set("service_name", service_name)
+        const modal_prompt = 'Enter the name of the service you wish to track incidents for:'
+
+        Modal.inputUserIncident(storage, modal_id, modal_prompt) // Creates a user prompt to save incident name to local storage
+
+        // service_name = prompt("Enter the name of the service you wish to track incidents for:")
+
+        // storage.set("service_name", service_name)
 
     }
-
-    document.querySelectorAll('span.service-name').forEach(el => {
-        el.innerHTML = service_name
-    })
 
     // Load in any previously created incidents
     let incidents = []
@@ -169,21 +173,23 @@ document.addEventListener('DOMContentLoaded', () => {
 
     document.getElementById("reset_everything").addEventListener("click", () => {
 
-        if (confirm("Are you sure you want to reset everything?")) {
+        Modal.resetProtocol(storage) // Three step protocol to reset local storage by prompting the user for confirmation
 
-            if (confirm("Are you absolutely sure you want to reset everything? This can NOT be undone.")) {
+        // if (confirm("Are you sure you want to reset everything?")) {
 
-                if (prompt(`Type "Anthony is the best" to confirm that you definitely, absolutely, certainly wish to reset everything.`) == "Anthony is the best") {
+        //     if (confirm("Are you absolutely sure you want to reset everything? This can NOT be undone.")) {
+
+        //         if (prompt(`Type "Anthony is the best" to confirm that you definitely, absolutely, certainly wish to reset everything.`) == "Anthony is the best") {
                     
-                    storage.remove("service_name")
-                    storage.remove("incidents")
-                    location.reload()
+        //             storage.remove("service_name")
+        //             storage.remove("incidents")
+        //             location.reload()
 
-                }
+        //         }
 
-            }
+        //     }
 
-        }
+        // }
 
     })
 

--- a/Main.js
+++ b/Main.js
@@ -167,39 +167,45 @@ document.addEventListener('DOMContentLoaded', () => {
 
     document.getElementById("set_service_name").addEventListener("click", () => {
 
-        Modal.modalPrompt(storage, 'Please enter the name of the service you wish to track incidents for.') // Creates a user prompt to save incident name to local storage
+        const promptUserIncidentName = new Modal.Modal('Enter the name of the service you wish to track incidents for.', 'Set Service Name', true)
+
+        promptUserIncidentName.prompt((input) => {
+
+            storage.set("service_name", input)
+
+            document.querySelectorAll('span.service-name').forEach(el => { el.innerHTML = input })
+
+        })
 
     })
 
+    
     // Reset protocol that creates bulma modals that confirm user wishes to clear local data
     document.getElementById('reset_everything').addEventListener("click", () => {
 
-        Modal.confirmReset('reset_warning_one', 'Do you wish to reset local storage?').then((confirmed) => {
+        const confirmReset_1 = new Modal.Modal('Do you wish to reset local storage?')
+        const confirmReset_2 = new Modal.Modal('Resetting will delete all data. Are you sure?')
+        const confirmReset_3 = new Modal.Modal("Please type 'YES' to proceed.", 'Danger', true)
 
-            if (confirmed) {
+        confirmReset_1.confirm((e) => { 
 
-                Modal.confirmReset('reset_warning_two', 'Resetting will delete all data: Are you sure?').then((confirmed) => {
+            e && confirmReset_2.confirm((e) => {
 
-                    if (confirmed) {
+                e && confirmReset_3.prompt((e) => {
 
-                        Modal.confirmReset('reset_warning_three', "Please type 'YES' to proceed.", 'YES', 'req-input').then((confirmed) => {
-
-                            confirmed ? (
-
-                                storage.remove("service_name"),
-                                storage.remove("incidents"),
-                                location.reload()
-
-                            ) : undefined
-                        })
-
-                    }
-
+                        e === 'YES' && (
+    
+                            storage.remove("service_name"),
+                            storage.remove("incidents"),
+                            location.reload()
+    
+                        )
+    
                 })
 
-            }
+            })
 
-        })
+         })
 
     })
 

--- a/Main.js
+++ b/Main.js
@@ -17,12 +17,7 @@ document.addEventListener('DOMContentLoaded', () => {
             el.innerHTML = service_name
         })
 
-    } else {
-
-        Modal.modalPrompt(storage, 'Enter the name of the service you wish to track incidents for:') // Creates a user prompt to save incident name to local storage
-
-    }
-
+    } 
 
     // Load in any previously created incidents
     let incidents = []
@@ -169,6 +164,12 @@ document.addEventListener('DOMContentLoaded', () => {
         return `<p>${incident.date} - ${incident_description}</p>`
 
     }
+
+    document.getElementById("set_service_name").addEventListener("click", () => {
+
+        Modal.modalPrompt(storage, 'Enter the name of the service you wish to track incidents for:') // Creates a user prompt to save incident name to local storage
+
+    })
 
     // Reset protocol that creates bulma modals that confirm user wishes to clear local data
     document.getElementById('reset_everything').addEventListener("click", () => {

--- a/Modal.js
+++ b/Modal.js
@@ -5,6 +5,7 @@ export class Modal {
     modal = `
         <div class="modal is-active" id="${this.#id}">
             <div class="modal-background"></div>
+            <button class="modal-close is-large" aria-label="close"></button>
             <div class="modal-card">
                 <header class="modal-card-head">
                     <p class="modal-card-title"></p>
@@ -133,7 +134,7 @@ export class Modal {
 
     #createCloseEvents() {
 
-        document.querySelectorAll('.modal-background, .delete, .close').forEach((el) => {
+        document.querySelectorAll('.modal-background, .delete, .modal-close').forEach((el) => {
 
             el.addEventListener('click', () => { this.#close() })
 

--- a/Modal.js
+++ b/Modal.js
@@ -1,0 +1,177 @@
+// Creates and appends the components for a bulma modal user prompt
+export function createModal(id, prompt, active) {
+
+  const container = document.createElement('div')
+  active ? container.classList.add('modal', 'is-active') : container.classList.add('modal')
+  container.setAttribute('id', id)
+  document.body.append(container)
+
+  const escape = document.createElement('button')
+  escape.classList.add('modal-close', 'is-large')
+  escape.setAttribute('aria-label', 'close')
+  container.append(escape)
+
+  const background = document.createElement('div')
+  background.classList.add('modal-background')
+  container.append(background)
+
+  const content = document.createElement('div')
+  content.classList.add('modal-content')
+  container.append(content)
+
+  const box = document.createElement('div')
+  box.classList.add('box')
+  content.append(box)
+
+  const label = document.createElement('label')
+  label.classList.add('label', 'is-size-5')
+  label.innerText = prompt
+
+  const control_label = document.createElement('div')
+  control_label.append(label)
+  box.append(control_label)
+
+  const input = document.createElement('input')
+  input.classList.add('input', 'is-normal')
+  input.setAttribute('type', 'text')
+
+  const control_input = document.createElement('div')
+  control_input.classList.add('control', 'is-expanded')
+  control_input.append(input)
+
+  const button = document.createElement('button')
+  button.classList.add('button', 'is-centered')
+  button.setAttribute('id', `${id}_submit`)
+  button.innerText = 'OK'
+
+  const control_button = document.createElement('div')
+  control_button.classList.add('control')
+  control_button.append(button)
+
+  const field = document.createElement('div')
+  field.classList.add('field', 'has-addons', 'mt-3')
+  field.append(control_input, control_button)
+  box.append(field)
+
+  // Add a click event on various child elements to delete the parent modal
+  const altCloseModal = (document.querySelectorAll('.modal-background, .modal-close, .modal-card-head .delete, .modal-card-foot .button') || []).forEach(($close) => {
+
+    const $target = $close.closest('.modal')
+
+    $close.addEventListener('click', () => {
+
+      deleteModal($target)
+
+    })
+
+  }) 
+
+  // Add a keyboard event to close all modals
+  const keyboard_close_modal = document.addEventListener('keydown', (event) => {
+
+    if (event.key === "Escape") { closeAllModals() }
+
+  })
+
+}  
+
+// A series of three user prompts to clear local storage
+export function resetProtocol(storage) {
+
+  const id_1 = 'reset_warning_one'
+  const id_2 = 'reset_warning_two'
+  const id_3 = 'reset_warning_three'
+
+  createModal(id_1, 'Do you wish to reset?', true)
+
+  document.getElementById(`${id_1}_submit`).addEventListener('click', () => {
+    
+    createModal(id_2, 'Resetting will delete all data: Are you sure?', true)
+
+    document.getElementById(`${id_2}_submit`).addEventListener('click', () => {
+
+      createModal(id_3, "Please type 'YES' to proceed.", true)
+
+      document.getElementById(`${id_3}_submit`).addEventListener('click', () => {
+
+        const input = document.getElementById(id_3).querySelector('input').value
+
+        input === 'YES' ? (
+
+          storage.remove("service_name"),
+          storage.remove("incidents"),
+          location.reload()
+
+        ) : deleteModal(id_3)
+
+      })
+
+    })
+
+  })
+
+} 
+
+// Processes a new user incident and places into local storage 
+export function inputUserIncident (storage, id, prompt) {
+
+  createModal(id, prompt)
+
+  const modal = document.getElementById(id)
+
+  openModal(modal)
+
+  const submit = document.getElementById(`${id}_submit`)
+  const input = modal.querySelector('input')
+
+  submit.addEventListener('click', () => {
+
+    const incident = input.value
+
+    storage.set("service_name", incident)
+
+    document.querySelectorAll('span.service-name').forEach(el => {
+        el.innerHTML = incident
+    })
+
+    deleteModal(undefined, id)
+
+  })
+
+}
+
+// Removes a modal from the dom
+export function deleteModal(element, id = undefined) {
+
+  const modalToDelete = id ? document.getElementById(id) : element
+
+  modalToDelete ? modalToDelete.remove() || element.remove() : console.log('No element found')
+
+}
+
+// Functions to open and close a modal
+export function openModal($el) {
+
+  $el.classList.add('is-active')
+
+}
+
+export function closeModal($el) {
+
+  $el.classList.remove('is-active')
+
+}
+
+export function closeAllModals() {
+
+  (document.querySelectorAll('.modal') || []).forEach(($modal) => {
+
+    deleteModal($modal);
+
+  })
+
+}
+
+
+  
+  

--- a/Modal.js
+++ b/Modal.js
@@ -1,8 +1,8 @@
 // Creates and appends the components for a bulma modal user prompt
-export function createModal(id, prompt, active) {
+export function createModal(id, prompt) {
 
   const container = document.createElement('div')
-  active ? container.classList.add('modal', 'is-active') : container.classList.add('modal')
+  container.classList.add('modal', 'is-active')
   container.setAttribute('id', id)
   document.body.append(container)
 
@@ -78,9 +78,7 @@ export function createModal(id, prompt, active) {
 // Creates bulma modals to confirm the user wishes to reset local storage
 export function confirmReset(id, prompt, correctResponse = undefined) {
 
-  const visible = true
-
-  createModal(id, prompt, visible)
+  createModal(id, prompt)
 
   return new Promise((resolve) => { // Waits for the user to click on the confirm button
 
@@ -120,9 +118,6 @@ export function modalPrompt (storage, prompt) {
   createModal(id, prompt)
 
   const modal = document.getElementById(id)
-
-  openModal(modal)
-
   const submit = document.getElementById(`${id}_submit`)
   const input = modal.querySelector('input')
 

--- a/Modal.js
+++ b/Modal.js
@@ -1,60 +1,84 @@
-// Creates and appends the components for a bulma modal user prompt
-export function createModal(id, prompt) {
+// Creates and appends the components for a bulma modal user msg
+export function createModal(id, msg, prompt_title = undefined, type = 'default') {
 
-  const container = document.createElement('div')
-  container.classList.add('modal', 'is-active')
-  container.setAttribute('id', id)
-  document.body.append(container)
+  /*
+  Modal element tree
 
-  const escape = document.createElement('button')
-  escape.classList.add('modal-close', 'is-large')
-  escape.setAttribute('aria-label', 'close')
-  container.append(escape)
+  modal
+    |---> background
+    |---> card 
+            |---> header
+            |       |---> title (optional)
+            |---> body
+            |       |---> message
+            |       |---> input (optional)
+            |---> footer
+                    |---> controls
+                            |---> positive (btn)
+                            |---> negative (btn)
+  */
+
+  const modal = document.createElement('div')
+  modal.classList.add('modal', 'is-active')
+  modal.setAttribute('id', id)
+  document.body.append(modal)
 
   const background = document.createElement('div')
   background.classList.add('modal-background')
-  container.append(background)
+  modal.append(background)
 
-  const content = document.createElement('div')
-  content.classList.add('modal-content')
-  container.append(content)
+  const card = document.createElement('div')
+  card.classList.add('modal-card')
+  modal.append(card)
 
-  const box = document.createElement('div')
-  box.classList.add('box')
-  content.append(box)
+  const header = document.createElement('header')
+  header.classList.add('modal-card-head', 'py-4')
+  card.append(header)
 
-  const label = document.createElement('label')
-  label.classList.add('label', 'is-size-5')
-  label.innerText = prompt
+  const body = document.createElement('section')
+  body.classList.add('modal-card-body', 'py-4')
+  prompt_title || type === 'req-input' ? card.append(body) : undefined
 
-  const control_label = document.createElement('div')
-  control_label.append(label)
-  box.append(control_label)
+  const footer = document.createElement('footer')
+  footer.classList.add('modal-card-foot', 'py-2')
+  card.append(footer)
 
-  const input = document.createElement('input')
-  input.classList.add('input', 'is-normal')
-  input.setAttribute('type', 'text')
+  const title = document.createElement('p')
+  prompt_title ? title.classList.add('modal-card-title') : title.classList.add('modal-card-title', 'is-size-6')
+  prompt_title ? title.innerText = prompt_title : title.innerText = msg
+  header.append(title)
 
-  const control_input = document.createElement('div')
-  control_input.classList.add('control', 'is-expanded')
-  control_input.append(input)
+  const message = document.createElement('p') 
+  message.classList.add('label', 'is-size-6')
+  prompt_title ? message.innerText = msg : undefined
+  body.append(message)
 
-  const button = document.createElement('button')
-  button.classList.add('button', 'is-centered')
-  button.setAttribute('id', `${id}_submit`)
-  button.innerText = 'OK'
+  if (type === 'req-input') {
+    const input = document.createElement('input')
+    input.setAttribute('type', 'text')
+    input.classList.add('input', 'is-focused')
+    body.append(input)
+  }
 
-  const control_button = document.createElement('div')
-  control_button.classList.add('control')
-  control_button.append(button)
+  const controls = document.createElement('div')
+  controls.classList.add('buttons', 'is-flex', 'is-justify-content-end', 'is-flex-grow-1')
+  footer.append(controls)
 
-  const field = document.createElement('div')
-  field.classList.add('field', 'has-addons', 'mt-3')
-  field.append(control_input, control_button)
-  box.append(field)
+  const button_positive = document.createElement('button')
+  button_positive.classList.add('button')
+  button_positive.setAttribute('id', `${id}_submit`)
+  button_positive.innerText = 'OK'
+  controls.append(button_positive)
 
+  const button_negative = document.createElement('button')
+  button_negative.classList.add('button', 'exit')
+  button_negative.setAttribute('id', `${id}_cancel`)
+  button_negative.innerText = 'Cancel'
+  controls.append(button_negative)
+
+  
   // Add a click event on various child elements to delete the parent modal
-  const altCloseModal = (document.querySelectorAll('.modal-background, .modal-close, .modal-card-head .delete, .modal-card-foot .button') || []).forEach(($close) => {
+  const altCloseModal = (document.querySelectorAll('.modal-background, .modal-close, .modal-card-head .delete, .modal-card-foot, .exit') || []).forEach(($close) => {
 
     const $target = $close.closest('.modal')
 
@@ -76,9 +100,9 @@ export function createModal(id, prompt) {
 }  
 
 // Creates bulma modals to confirm the user wishes to reset local storage
-export function confirmReset(id, prompt, correctResponse = undefined) {
+export function confirmReset(id, msg, correctResponse = undefined, type = undefined) {
 
-  createModal(id, prompt)
+  createModal(id, msg, undefined, type)
 
   return new Promise((resolve) => { // Waits for the user to click on the confirm button
 
@@ -87,7 +111,7 @@ export function confirmReset(id, prompt, correctResponse = undefined) {
       if (correctResponse) {
 
         const response = document.getElementById(id).querySelector('input').value
-
+        
         if (response === correctResponse) {
 
           resolve(response)
@@ -111,11 +135,12 @@ export function confirmReset(id, prompt, correctResponse = undefined) {
 } 
 
 // Processes a new user incident and places into local storage 
-export function modalPrompt (storage, prompt) {
+export function modalPrompt (storage, msg) {
 
   const id = 'service_name_container'
+  const title = 'Incident Name'
 
-  createModal(id, prompt)
+  createModal(id, msg, title, 'req-input')
 
   const modal = document.getElementById(id)
   const submit = document.getElementById(`${id}_submit`)

--- a/Modal.js
+++ b/Modal.js
@@ -1,6 +1,6 @@
 export class Modal {
 
-    #id = 'modal-version-04/13/2024'
+    #id = 'new.modal'
 
     modal = `
         <div class="modal is-active" id="${this.#id}">
@@ -30,7 +30,7 @@ export class Modal {
     constructor(message, title, primaryBtnText, secondaryBtnText) {
 
         this.title = title ?? 'Attention' 
-        this.message = message ?? 'This is the default alert message. Have a great day!'
+        this.message = message ?? 'Do you wish to proceed?'
         this.requireUserInput = false
         this.primaryBtnText = primaryBtnText ?? 'OK'
         this.secondaryBtnText = secondaryBtnText ?? 'Cancel'
@@ -86,7 +86,8 @@ export class Modal {
             primaryButton.addEventListener('click', () => {
 
                 funcToRunOnOkay(userInput.value)
-            
+                this.#close()
+
             })
 
         }
@@ -96,6 +97,7 @@ export class Modal {
             if (funcToRunOnCancel) {
 
                 funcToRunOnCancel(userInput.value)
+                this.#close()
                 
             } else { this.#close() }
 
@@ -125,6 +127,7 @@ export class Modal {
             if (funcToRunOnCancel) {
 
                 funcToRunOnCancel(userInput.value)
+                this.#close()
                 
             } else { this.#close() }
 

--- a/Modal.js
+++ b/Modal.js
@@ -75,37 +75,37 @@ export function createModal(id, prompt, active) {
 
 }  
 
-// A series of three user prompts to clear local storage
-export function resetProtocol(storage) {
+// Creates bulma modals to confirm the user wishes to reset local storage
+export function confirmReset(id, prompt, correctResponse = undefined) {
 
-  const id_1 = 'reset_warning_one'
-  const id_2 = 'reset_warning_two'
-  const id_3 = 'reset_warning_three'
+  const visible = true
 
-  createModal(id_1, 'Do you wish to reset?', true)
+  createModal(id, prompt, visible)
 
-  document.getElementById(`${id_1}_submit`).addEventListener('click', () => {
-    
-    createModal(id_2, 'Resetting will delete all data: Are you sure?', true)
+  return new Promise((resolve) => { // Waits for the user to click on the confirm button
 
-    document.getElementById(`${id_2}_submit`).addEventListener('click', () => {
+    document.getElementById(`${id}_submit`).addEventListener('click', () => {
 
-      createModal(id_3, "Please type 'YES' to proceed.", true)
+      if (correctResponse) {
 
-      document.getElementById(`${id_3}_submit`).addEventListener('click', () => {
+        const response = document.getElementById(id).querySelector('input').value
 
-        const input = document.getElementById(id_3).querySelector('input').value
+        if (response === correctResponse) {
 
-        input === 'YES' ? (
+          resolve(response)
 
-          storage.remove("service_name"),
-          storage.remove("incidents"),
-          location.reload()
+          deleteModal(undefined, id)
 
-        ) : deleteModal(id_3)
+        } else { deleteModal(undefined, id) }
 
-      })
+      } else {
 
+        resolve(true)
+
+        deleteModal(undefined, id)
+
+      }
+  
     })
 
   })
@@ -113,7 +113,9 @@ export function resetProtocol(storage) {
 } 
 
 // Processes a new user incident and places into local storage 
-export function inputUserIncident (storage, id, prompt) {
+export function modalPrompt (storage, prompt) {
+
+  const id = 'service_name_container'
 
   createModal(id, prompt)
 
@@ -145,7 +147,7 @@ export function deleteModal(element, id = undefined) {
 
   const modalToDelete = id ? document.getElementById(id) : element
 
-  modalToDelete ? modalToDelete.remove() || element.remove() : console.log('No element found')
+  modalToDelete.remove()
 
 }
 

--- a/Modal.js
+++ b/Modal.js
@@ -1,6 +1,6 @@
 export class Modal {
 
-    #id = 'new.modal'
+    #id = 'modal'
 
     modal = `
         <div class="modal is-active" id="${this.#id}">

--- a/Modal.js
+++ b/Modal.js
@@ -21,11 +21,11 @@ export class Modal {
         </div> 
     `
 
-    constructor(message, title, input, primaryBtnText, secondaryBtnText) {
+    constructor(message, title, primaryBtnText, secondaryBtnText) {
 
         this.title = title || 'Attention' 
         this.message = message || 'This is the default alert message. Have a great day!'
-        this.requireUserInput = input || false
+        this.requireUserInput = false
         this.primaryBtnText = primaryBtnText || 'OK'
         this.secondaryBtnText = secondaryBtnText || 'Cancel'
     }
@@ -73,6 +73,7 @@ export class Modal {
 
     prompt(userFunction = undefined, alternateFunction = undefined) {
 
+        this.requireUserInput = true
         this.#createTemplate()
 
         const primaryButton = document.getElementById('modal-primary-button')
@@ -113,7 +114,6 @@ export class Modal {
             if (userFunction) {
 
                 userFunction(true)
-
 
             }
 

--- a/index.html
+++ b/index.html
@@ -42,7 +42,10 @@
         <div class="content is-small">
             <p>Data is <span class="is-italic">not</span> transferred between machines but <span class="is-italic">is</span> preserved when closing and re-opening the site in the same browser.</p>
             <p><a href="https://github.com/anthonyisensee/incidenttracker/issues/new?labels=bug">Report an issue</a> or <a href="https://github.com/anthonyisensee/incidenttracker/issues/new?labels=enhancement">submit a feature request</a>. Feel free to fork <a href="https://github.com/anthonyisensee/incidenttracker">the code</a> and submit a <a href="https://github.com/anthonyisensee/incidenttracker/pulls">pull request</a>.</p>
-            <p>Developed by <a href="https://github.com/anthonyisensee">Anthony Isensee</a> for Ricky Moore. 🖤</p>
+            <p>
+                Developed by <a href="https://github.com/anthonyisensee">Anthony Isensee</a> for Ricky Moore. 🖤
+                Thank you to <a href="https://github.com/geo-bold">Geo Archbold</a> for contributions.
+            </p>
         </div>
     </footer>
 </body>


### PR DESCRIPTION
Resolves the use of Bulma modals instead of JS prompts while retaining as much initial structure as possible. Modal creating function is easily reusable and is not rendered to the DOM until called. A garbage collection function ensures that no duplicated modals remain rendered at one time.

For the local storage reset protocol, there is similar structure to the original JS prompts and confirms. So far, there exists control over the prompt and establishment of a generic default.

Further changes would be centered around enhancing the functionality of the modal creating function to allow for more control over each modal generated as well as revisiting the current style for the prompts to include two buttons, making them larger and removing the input field when not necessary.